### PR TITLE
Can build rdm, rc, rp on Windows with MSYS2 MinGW-w64

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -24,6 +24,7 @@ struct UserData {
     List<AST::Cursor> parents;
     AST *ast;
 };
+
 CXChildVisitResult AST::visitor(CXCursor cursor, CXCursor, CXClientData u)
 {
     UserData *userData = reinterpret_cast<UserData*>(u);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,13 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug")
     set(RCT_EVENTLOOP_CALLBACK_TIME_THRESHOLD 2000)
 endif ()
 
+
+# normalize windows style path
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    string(REPLACE "\\" "/" LIBCLANG_LIBDIR "${LIBCLANG_LIBDIR}")
+    string(REPLACE "\\" "/" RTAGS_SOURCE_DIR "${RTAGS_SOURCE_DIR}")
+endif()
+
 add_definitions(
     "-DRTAGS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
     "-DCLANG_LIBDIR=${LIBCLANG_LIBDIR}"
@@ -141,6 +148,10 @@ set(RTAGS_SOURCES
     Token.cpp
     TokensJob.cpp
     ${RCT_SOURCES})
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    list(APPEND RTAGS_SOURCES windows_mktemp.cpp)
+endif ()
 
 if (LUA_ENABLED)
     list(APPEND RTAGS_SOURCES AST.cpp)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -17,7 +17,12 @@
 #include <rct/ThreadPool.h>
 #include "TokensJob.h"
 
+#ifndef _WIN32
 #include <arpa/inet.h>
+#else // _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Winsock2.h>
+#endif // _WIN32
 #include <clang-c/Index.h>
 #include <clang-c/CXCompilationDatabase.h>
 #include <stdio.h>

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -21,6 +21,10 @@
 #include "RTags.h"
 #include "Server.h"
 
+#ifdef _WIN32
+#include <windows_mktemp.h>
+#endif // _WIN32
+
 void Source::clear()
 {
     fileId = compilerId = buildRootId = compileCommandsFileId = 0;
@@ -305,7 +309,11 @@ static inline bool isCompiler(const Path &fullPath, const List<String> &environm
 
     char path[PATH_MAX];
     strcpy(path, "/tmp/rtags-compiler-check-XXXXXX.c");
+    #ifndef _WIN32
     const int fd = mkstemps(path, 2);
+    #else
+    const int fd = windows_mkstemps(path, 2);
+    #endif
     if (fd == -1) {
         error("Failed to make temporary file errno: %d", errno);
         return false;

--- a/src/windows-todo.org
+++ b/src/windows-todo.org
@@ -5,37 +5,127 @@ Useful Link: [[http://66.165.136.43/dictionary/index.php][Unix to Windows Portin
 
 * Errors by cause
 
-** TODO no connectUnix() in class [[file:rct/rct/Connection.h][Connection]] (rct)
+** DONE no connectUnix() in class [[file:rct/rct/Connection.h][Connection]] (rct)
+   CLOSED: [2017-05-28 Sun 21:05]
 
-We need to find a way to implement this on Windows.
+   We need to find a way to implement this on Windows.
 
-I think using Windows pipes is *not* a good idea, because they are difficult to
-use. I suggest falling back to TCP.
+   I think using Windows pipes is *not* a good idea, because they are difficult to
+   use. I suggest falling back to TCP.
 
-Unix pipes work with special files. Maybe we can emulate this behavior on
-Windows by implementing connectUnix() to read the tcp connection parameters
-(i.e., the port) from the file representing the pipe.
+   Unix pipes work with special files. Maybe we can emulate this behavior on
+   Windows by implementing connectUnix() to read the tcp connection parameters
+   (i.e., the port) from the file representing the pipe.
 
 *** Occurences
-- [[file:ClangIndexer.cpp::197][ClangIndex.cpp Line 197]]
-- [[file:RClient.cpp::404][RClient.cpp Line 404]]
 
-** TODO arpa/inet.h not found
+    - [[file:ClangIndexer.cpp::197][ClangIndex.cpp Line 197]]
+    - [[file:RClient.cpp][RClient.cpp]]
 
-Replace with windows-specific include (i.e. Winsock2.h). Might also need to
-#define WIN32_LEAN_AND_MEAN.
+*** Solution
+
+    Falling back to TCP on Windows.
+
+    At server side. use =SocketServer::listen(0)= internally.
+    listen on port zero to let OS pick a port available, and than write the
+    port number (pick by the OS) back to the file specified by =path=.
+
+    At client side, while connect to a file, first read the port number from file,
+    then connect to =localhost= with that port number.
+
+    - implemented functions:
+      - bool SocketServer::listen(const Path &path)
+      - bool SocketClient::connect(const String& path)
+
+** DONE arpa/inet.h not found
+   CLOSED: [2017-05-28 Sun 21:05]
+
+   Replace with windows-specific include (i.e. Winsock2.h). Might also need to
+   #define WIN32_LEAN_AND_MEAN.
 
 *** Occurrences
-- [[file:Server.cpp::20][Server.cpp]]
+    - [[file:Server.cpp::20][Server.cpp]]
 
-** TODO mkstemps not declared
+*** Solution
+    Replace with windows-specific include =Winsock2.h=.
 
-mktemps() creates a temporary file that is guaranteed to be unique and opens
-it.
+** DONE mkstemps and mkdtemp not declared
+   CLOSED: [2017-05-28 Sun 21:05]
 
-Windows has _mktemp_s() and _wmktemp_s(). Check whether these can be used and
-put them in. Should use the wide function in connection with rct's
-WindowsUnicodeConversions.
+   mktemps() creates a temporary file that is guaranteed to be unique and opens
+   it.
+
+   Windows has _mktemp_s() and _wmktemp_s(). Check whether these can be used and
+   put them in. Should use the wide function in connection with rct's
+   WindowsUnicodeConversions.
 
 *** Occurences
-- [[file:Source.cpp::308][Source.cpp Line 308]]
+    - [[file:Source.cpp][Source.cpp]]
+    - [[file:rdm.cpp][rdm.cpp]]
+
+** DONE invalid argument in function getNameHelper
+   CLOSED: [2017-05-28 Sun 21:31]
+
+   Invalid conversion from =int (__attribute__((__stdcall__))*) (SOCKET, sockaddr *, int)=
+   to =GetNameFunc {aka int (*)(unsigned int, sockaddr *, int *)}= while initializing
+   argument 2 of 'String getNameHelper(int, GetNameFunc, uint16_t *)'
+
+*** Occurences
+    - [[file:rct/rct/SocketClient.cpp::372][SocketClient.cpp Line 372]]
+
+*** Current solution
+
+    Add =WINAPI= into the signature of =GetNameFunc= in Windows.
+
+** DONE warning of unknown conversion type charecter 'z' in format
+   CLOSED: [2017-05-28 Sun 21:51]
+
+*** Occurences
+    - [[file:rct/rct/String.cpp][String.cpp]]
+
+*** Current solution
+
+    In macro =RCT_PRINTF_WARNING=, using =__MINGW_PRINTF_FORMAT= instead of =__printf__=
+    for format checking. Solution for =msvc= still needed.
+
+*** Reference
+    [[https://stackoverflow.com/questions/10678124/mingw-gcc-unknown-conversion-type-character-h-snprintf][StackOverflow: MinGW GCC: “Unknown conversion type character 'h'” (snprintf)]]
+
+** DONE fork, setsid not declared
+   CLOSED: [2017-05-28 Sun 22:09]
+
+   When option =--daemon= is specified in arguments of =rdm=, it forks and starts a daemon in background.
+
+*** Occurences
+    - [[file:rdm.cpp::825][rdm.cpp Line 825]]
+
+*** Solution
+
+    Currently option =--daemon= is not supported on Windows.
+    When option =--daemon= specified, always return with a non-zero value to indcate.
+
+** DONE Process::findCommand not defined on windows
+   CLOSED: [2017-05-28 Sun 22:09]
+
+   When option =--daemon= is specified in arguments of =rdm=, it forks and starts a
+   daemon in background.
+
+*** Occurences
+    - [[file:rct/rct/Process_Windows.cpp][Process_Windows.cpp]]
+
+*** Solution
+
+    Define this function in =Process_Windows.cpp=, implementation copied from =Process.cpp=,
+    with some minor modifications.
+
+** DONE unknown escaped sequence in expension of macro 'TO_STR(RTAGS_SOURCE_DIR)'
+   CLOSED: [2017-05-29 Mon 21:48]
+
+   Windows uses backslash '\' as directory separator by default, thus causing this warning while
+   making it into a C-string-literal by macro 'TO_STR'.
+
+*** Occurences
+    - [[file:AST.cpp][AST.cpp]]
+
+*** Solution
+    Normalize 'RTAGS_SOURCE_DIR', replace backslash with slash, in CMakeLists.txt .

--- a/src/windows_mktemp.cpp
+++ b/src/windows_mktemp.cpp
@@ -1,0 +1,204 @@
+#include "windows_mktemp.h"
+#include <rct/WindowsUnicodeConversion.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <windows.h>
+
+static const char letters[] =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+int windows_mkdtemp(char *tmpl)
+{
+    int len;
+    char *XXXXXX;
+    static unsigned long long value;
+    unsigned long long random_time_bits;
+    unsigned int count;
+    int result = -1;
+    int save_errno = errno;
+
+    // A lower bound on the number of temporary files to attempt to
+    // generate.  The maximum total number of temporary file names that
+    // can exist for a given tmplate is 62**6.  It should never be
+    // necessary to try all these combinations.  Instead if a reasonable
+    // number of names is tried (we define reasonable as 62**3) fail to
+    // give the system administrator the chance to remove the problems.
+    enum { ATTEMPTS_MIN = (62 * 62 * 62) };
+
+    // The number of times to attempt to generate a temporary file.  To
+    // conform to POSIX, this must be no smaller than TMP_MAX.
+    enum { ATTEMPTS = ATTEMPTS_MIN < TMP_MAX ? TMP_MAX : ATTEMPTS_MIN };
+
+    len = strlen (tmpl);
+    if (len < 6 || strcmp (&tmpl[len - 6], "XXXXXX"))
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // This is where the Xs start.
+    XXXXXX = &tmpl[len - 6];
+
+    // Get some more or less random data.
+    {
+        SYSTEMTIME      stNow;
+        FILETIME        ftNow;
+
+        // get system time
+        GetSystemTime(&stNow);
+        stNow.wMilliseconds = 500;
+        if (!SystemTimeToFileTime(&stNow, &ftNow))
+        {
+            errno = -1;
+            return -1;
+        }
+
+        random_time_bits = (((unsigned long long)ftNow.dwHighDateTime << 32)
+                            | (unsigned long long)ftNow.dwLowDateTime);
+    }
+    value += random_time_bits ^ (unsigned long long)GetCurrentThreadId ();
+
+    for (count = 0; count < ATTEMPTS; value += 7777, ++count)
+    {
+        unsigned long long v = value;
+
+        // Fill in the random bits.
+        XXXXXX[0] = letters[v % 62];
+        v /= 62;
+        XXXXXX[1] = letters[v % 62];
+        v /= 62;
+        XXXXXX[2] = letters[v % 62];
+        v /= 62;
+        XXXXXX[3] = letters[v % 62];
+        v /= 62;
+        XXXXXX[4] = letters[v % 62];
+        v /= 62;
+        XXXXXX[5] = letters[v % 62];
+
+        Utf8To16 wtmpl(tmpl);
+        result = _wmkdir(wtmpl.asWchar_t());
+        if (result >= 0)
+        {
+            errno = save_errno;
+            return result;
+        }
+        else if (errno != EEXIST)
+            return -1;
+    }
+
+    // We got out of the loop because we ran out of combinations to try.
+    errno = EEXIST;
+    return -1;
+}
+
+int windows_mkstemp(char *tmpl)
+{
+    return windows_mkostemps(
+        tmpl,
+        0,
+        O_RDWR | O_CREAT | O_EXCL);
+}
+
+int windows_mkostemp(char *tmpl, int flags)
+{
+    return windows_mkostemps(
+        tmpl,
+        0,
+        flags);
+}
+
+int windows_mkstemps(char *tmpl, int suffixlen)
+{
+    return windows_mkostemps(
+        tmpl,
+        suffixlen,
+        O_RDWR | O_CREAT | O_EXCL);
+}
+
+int windows_mkostemps(char *tmpl, int suffixlen, int flags)
+{
+    int len;
+    char *XXXXXX;
+    static unsigned long long value;
+    unsigned long long random_time_bits;
+    unsigned int count;
+    int fd = -1;
+    int save_errno = errno;
+    int xs_begin_pos;
+
+    // A lower bound on the number of temporary files to attempt to
+    // generate.  The maximum total number of temporary file names that
+    // can exist for a given tmplate is 62**6.  It should never be
+    // necessary to try all these combinations.  Instead if a reasonable
+    // number of names is tried (we define reasonable as 62**3) fail to
+    // give the system administrator the chance to remove the problems.
+    enum { XS_COUNT = 6};
+    enum { ATTEMPTS_MIN = (62 * 62 * 62) };
+
+    // The number of times to attempt to generate a temporary file.  To
+    // conform to POSIX, this must be no smaller than TMP_MAX.
+    enum { ATTEMPTS = ATTEMPTS_MIN < TMP_MAX ? TMP_MAX : ATTEMPTS_MIN };
+
+    len = strlen (tmpl);
+    xs_begin_pos = len - 6 - suffixlen;
+    if (xs_begin_pos < 0 || strcmp (&tmpl[xs_begin_pos], "XXXXXX"))
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // This is where the Xs start.
+    XXXXXX = &tmpl[xs_begin_pos];
+
+    // Get some more or less random data.
+    {
+        SYSTEMTIME      stNow;
+        FILETIME        ftNow;
+
+        // get system time
+        GetSystemTime(&stNow);
+        stNow.wMilliseconds = 500;
+        if (!SystemTimeToFileTime(&stNow, &ftNow))
+        {
+            errno = -1;
+            return -1;
+        }
+
+        random_time_bits = (((unsigned long long)ftNow.dwHighDateTime << 32)
+                            | (unsigned long long)ftNow.dwLowDateTime);
+    }
+    value += random_time_bits ^ (unsigned long long)GetCurrentThreadId ();
+
+    for (count = 0; count < ATTEMPTS; value += 7777, ++count)
+    {
+        unsigned long long v = value;
+
+        // Fill in the random bits.
+        XXXXXX[0] = letters[v % 62];
+        v /= 62;
+        XXXXXX[1] = letters[v % 62];
+        v /= 62;
+        XXXXXX[2] = letters[v % 62];
+        v /= 62;
+        XXXXXX[3] = letters[v % 62];
+        v /= 62;
+        XXXXXX[4] = letters[v % 62];
+        v /= 62;
+        XXXXXX[5] = letters[v % 62];
+
+        Utf8To16 wtmpl(tmpl);
+        fd = _wopen(wtmpl.asWchar_t(), flags, _S_IREAD | _S_IWRITE);
+        if (fd >= 0)
+        {
+            errno = save_errno;
+            return fd;
+        }
+        else if (errno != EEXIST)
+            return -1;
+    }
+
+    // We got out of the loop because we ran out of combinations to try.
+    errno = EEXIST;
+    return -1;
+}

--- a/src/windows_mktemp.h
+++ b/src/windows_mktemp.h
@@ -1,0 +1,12 @@
+#ifndef WINDOWS_MKTEMP_H
+#define WINDOWS_MKTEMP_H
+#ifdef _WIN32
+
+int windows_mkdtemp(char *tmpl);
+int windows_mkstemp(char *tmpl);
+int windows_mkostemp(char *tmpl, int flags);
+int windows_mkstemps(char *tmpl, int suffixlen);
+int windows_mkostemps(char *tmpl, int suffixlen, int flags);
+
+#endif // _WIN32
+#endif // WINDOWS_MKTEMP_H


### PR DESCRIPTION
* Normailze RTAGS_SOURCE_DIR

  so that it could be made into string-literal correctly

  file: src/CMakeLists.txt
  file: src/AST.cpp

* Implement mkdtemp, mkstemp, mkstemps for Windows

  mkdtemp and mkstemp required by [[file:src/rdm.cpp]]
  mkstemps required by [[file:src/Source.cpp]]

  implemented in
  file: src/windows_mktemp.h
  file: src/windows_mktemp.cpp

* Use LogStderr instead of LogSyslog

  There is no syslog.h on Windows, switch to stderr instead.

  file: src/rp.cpp

* Signal SIGBUS is not supported on Windows

  Ignore this signal on Windows.

* fork is not defined on Windows

  fork is needed for '--daemon' flag in rdm. Currently, with this flag
  is specified on Windows (non-cygwin and non-msys gcc), it does nothing
  but fail with a non-zero return value.

  file: src/rdm.cpp